### PR TITLE
Error during iOS build

### DIFF
--- a/platforms/ios/Podfile
+++ b/platforms/ios/Podfile
@@ -1,2 +1,1 @@
-platform :ios, '8.0'
 pod 'Toast', '~> 3.0'


### PR DESCRIPTION
I've found that platform declaration in the podfile threw the duplicate platform declaration error during build for iOS. Without it, everything is working as expected.